### PR TITLE
Fix sidebar background and dropdown closing

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -96,15 +96,15 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, activeTab, setActiveTab 
                                     onClick={() => setActiveTab(item.id)}
                                     className={`group w-full flex items-center px-3 py-3 text-right rtl:text-right ltr:text-left rounded-lg transition-all duration-200 ${
                                         isActive 
-                                            ? 'bg-white/10 text-white shadow-lg border-r-2 rtl:border-r-2 ltr:border-l-2 border-white' 
-                                            : 'text-white/70 hover:text-white hover:bg-white/5'
+                                            ? 'bg-accent-primary/10 text-accent-primary shadow-lg border-r-2 rtl:border-r-2 ltr:border-l-2 border-accent-primary' 
+                                            : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary'
                                     }`}
                                     title={item.description}
                                 >
                                     <div className={`p-2 rounded-lg transition-all duration-200 ${
                                         isActive 
-                                            ? 'bg-white/20 text-white' 
-                                            : 'text-white/70 group-hover:text-white group-hover:bg-white/10'
+                                            ? 'bg-accent-primary/20 text-accent-primary' 
+                                            : 'text-text-tertiary group-hover:text-text-primary group-hover:bg-bg-tertiary'
                                     }`}>
                                         <Icon className="h-5 w-5" />
                                     </div>
@@ -113,7 +113,7 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, activeTab, setActiveTab 
                                     {/* Active indicator */}
                                     {isActive && (
                                         <div className="ml-auto rtl:ml-auto ltr:mr-auto">
-                                            <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                                            <div className="w-2 h-2 bg-accent-primary rounded-full animate-pulse" />
                                         </div>
                                     )}
                                 </button>
@@ -123,10 +123,10 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, activeTab, setActiveTab 
                 </nav>
 
                 {/* Footer */}
-                <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-white/10">
+                <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-border-primary">
                     <div className="text-center">
-                        <p className="text-white/60 text-xs">Version 2.0.0</p>
-                        <p className="text-white/40 text-xs mt-1">© 2024 Pars Wholesale</p>
+                        <p className="text-text-tertiary text-xs">Version 2.0.0</p>
+                        <p className="text-text-muted text-xs mt-1">© 2024 Pars Wholesale</p>
                     </div>
                 </div>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,7 @@
   --bg-primary: #ffffff;
   --bg-secondary: #f8fafc;
   --bg-tertiary: #f1f5f9;
-  --bg-sidebar: #1e293b;
+  --bg-sidebar: #f8fafc;
   --bg-card: #ffffff;
   --bg-overlay: rgba(0, 0, 0, 0.5);
   
@@ -79,7 +79,7 @@
   --bg-primary: #0f172a;
   --bg-secondary: #1e293b;
   --bg-tertiary: #334155;
-  --bg-sidebar: #020617;
+  --bg-sidebar: #1e293b;
   --bg-card: #1e293b;
   --bg-overlay: rgba(0, 0, 0, 0.7);
   

--- a/src/modals/BundleModal.tsx
+++ b/src/modals/BundleModal.tsx
@@ -1,5 +1,5 @@
 // components/BundleModal.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { products } from '../data/mockData';
 
 interface BundleModalProps {
@@ -10,6 +10,29 @@ const BundleModal: React.FC<BundleModalProps> = ({ onClose }) => {
     const [bundleName, setBundleName] = useState('');
     const [bundlePrice, setBundlePrice] = useState('');
     const [selectedProducts, setSelectedProducts] = useState<number[]>([]);
+    const modalRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+                onClose();
+            }
+        };
+
+        const handleEscapeKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleEscapeKey);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('keydown', handleEscapeKey);
+        };
+    }, [onClose]);
 
     const handleProductToggle = (productId: number) => {
         setSelectedProducts(prev => 
@@ -31,8 +54,8 @@ const BundleModal: React.FC<BundleModalProps> = ({ onClose }) => {
     };
 
     return (
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
-            <div className="bg-white rounded-lg p-6 w-full max-w-lg">
+        <div className="fixed inset-0 bg-bg-overlay z-50 flex items-center justify-center">
+            <div ref={modalRef} className="bg-bg-card rounded-lg p-6 w-full max-w-lg shadow-xl border border-border-primary">
                 <h3 className="text-lg font-semibold mb-4">ساخت بسته ترکیبی</h3>
                 <form onSubmit={handleSubmit} className="space-y-4">
                     <input
@@ -40,11 +63,11 @@ const BundleModal: React.FC<BundleModalProps> = ({ onClose }) => {
                         placeholder="نام بسته"
                         value={bundleName}
                         onChange={(e) => setBundleName(e.target.value)}
-                        className="w-full p-2 border border-gray-300 rounded-md"
+                        className="input"
                         required
                     />
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                        <label className="block text-sm font-medium text-text-secondary mb-2">
                             انتخاب محصولات:
                         </label>
                         <div className="space-y-2 max-h-40 overflow-y-auto">
@@ -56,7 +79,7 @@ const BundleModal: React.FC<BundleModalProps> = ({ onClose }) => {
                                         checked={selectedProducts.includes(product.id)}
                                         onChange={() => handleProductToggle(product.id)}
                                     />
-                                    <span className="text-sm">{product.name}</span>
+                                    <span className="text-sm text-text-primary">{product.name}</span>
                                 </label>
                             ))}
                         </div>
@@ -66,7 +89,7 @@ const BundleModal: React.FC<BundleModalProps> = ({ onClose }) => {
                         placeholder="قیمت بسته"
                         value={bundlePrice}
                         onChange={(e) => setBundlePrice(e.target.value)}
-                        className="w-full p-2 border border-gray-300 rounded-md"
+                        className="input"
                         min="0"
                         required
                     />
@@ -74,13 +97,13 @@ const BundleModal: React.FC<BundleModalProps> = ({ onClose }) => {
                         <button
                             type="button"
                             onClick={onClose}
-                            className="px-4 py-2 text-gray-600 hover:text-gray-800"
+                            className="btn btn-secondary"
                         >
                             انصراف
                         </button>
                         <button
                             type="submit"
-                            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                            className="btn btn-primary"
                         >
                             ساخت بسته
                         </button>

--- a/src/modals/ProductModal.tsx
+++ b/src/modals/ProductModal.tsx
@@ -1,5 +1,5 @@
 // components/ProductModal.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 interface ProductModalProps {
     onClose: () => void;
@@ -18,6 +18,7 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
         price: '',
         stock: ''
     });
+    const modalRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (product) {
@@ -29,6 +30,28 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
             });
         }
     }, [product]);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+                onClose();
+            }
+        };
+
+        const handleEscapeKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleEscapeKey);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+            document.removeEventListener('keydown', handleEscapeKey);
+        };
+    }, [onClose]);
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target;
@@ -46,8 +69,8 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
     };
 
     return (
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
-            <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <div className="fixed inset-0 bg-bg-overlay z-50 flex items-center justify-center">
+            <div ref={modalRef} className="bg-bg-card rounded-lg p-6 w-full max-w-md shadow-xl border border-border-primary">
                 <h3 className="text-lg font-semibold mb-4">
                     {product ? 'ویرایش محصول' : 'افزودن محصول جدید'}
                 </h3>
@@ -58,7 +81,7 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
                         placeholder="نام محصول"
                         value={formData.name}
                         onChange={handleInputChange}
-                        className="w-full p-2 border border-gray-300 rounded-md"
+                        className="input"
                         required
                     />
                     <input
@@ -67,7 +90,7 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
                         placeholder="دسته‌بندی"
                         value={formData.category}
                         onChange={handleInputChange}
-                        className="w-full p-2 border border-gray-300 rounded-md"
+                        className="input"
                         required
                     />
                     <input
@@ -76,7 +99,7 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
                         placeholder="قیمت"
                         value={formData.price}
                         onChange={handleInputChange}
-                        className="w-full p-2 border border-gray-300 rounded-md"
+                        className="input"
                         min="0"
                         required
                     />
@@ -86,7 +109,7 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
                         placeholder="موجودی"
                         value={formData.stock}
                         onChange={handleInputChange}
-                        className="w-full p-2 border border-gray-300 rounded-md"
+                        className="input"
                         min="0"
                         required
                     />
@@ -94,13 +117,13 @@ const ProductModal: React.FC<ProductModalProps> = ({ onClose, product }) => {
                         <button
                             type="button"
                             onClick={onClose}
-                            className="px-4 py-2 text-gray-600 hover:text-gray-800"
+                            className="btn btn-secondary"
                         >
                             انصراف
                         </button>
                         <button
                             type="submit"
-                            className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+                            className="btn btn-success"
                         >
                             ذخیره
                         </button>


### PR DESCRIPTION
Adjusts sidebar background colors for theme consistency and enables click-outside-to-close for modals.

The sidebar previously used fixed dark background colors, leading to an inconsistent appearance in both light and dark themes. This PR updates the CSS variables to ensure the sidebar background adapts correctly. Additionally, modals now close when clicking outside their content or pressing the Escape key, addressing a key UX issue where users had to click the modal content itself to dismiss it.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e7bbdef-928a-47f4-869c-712aedd77a07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e7bbdef-928a-47f4-869c-712aedd77a07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

